### PR TITLE
#806 Added "Duplicate Block(s)" keyboard shortcut

### DIFF
--- a/code/mouse_helpers.js
+++ b/code/mouse_helpers.js
@@ -624,6 +624,11 @@ function copy_selection(target){
 	}
 }
 
+function duplicate_selection() {
+    copy_selection();
+    blocks_paste(0);
+}
+
 function change_upsampling(b,u){ // send block, -1 to just set it for all voices.
 	if(u>-1){
 		blocks.replace("blocks["+b+"]::upsample",u);

--- a/data/keymap.json
+++ b/data/keymap.json
@@ -118,6 +118,7 @@
         "374" : ["ctrl-V", "blocks_paste", 0],
         "377" : ["ctrl-Y", "redo_button"],
         "378" : ["ctrl-Z", "undo_button"],
+        "356" : ["ctrl-D", "duplicate_selection"],
         "628" : ["shift-T", "select_tree_key"],
         "2420" : ["ctrl-alt-T", "reset_set_timer"],
         "2422" : ["ctrl-alt-V", "blocks_paste", 1],


### PR DESCRIPTION
Tested on macOS, but Windows support is still unverified. The "Duplicate" keyboard shortcut (Ctrl/Cmd + D) successfully copies and pastes a block or group of blocks in one step. When duplicating multiple connected blocks, their wiring is preserved and duplicated as well.