### PR TITLE
#809 Fix sidebar parameter text not updating from LFOs

### DIFF
--- a/code/clocked.js
+++ b/code/clocked.js
@@ -313,7 +313,7 @@ function check_changed_queue(){
 		p = Math.floor(t - b*MAX_PARAMETERS);
 		if(b==sidebar.selected){
 			// if(!is_empty(paramslider_details[p])){
-				redraw_flag.targets[p] |= 1;
+				redraw_flag.targets[p] = 2;
 				redraw_flag.flag |= 1;														
 			// }
 		}


### PR DESCRIPTION
This commit fixes a UI bug where a parameter's text value in the sidebar would not update in real-time when driven by a modulator like an LFO, even though the slider's fader moved correctly. The root cause was that programmatic parameter changes coming from the audio engine were only flagging the UI for a partial redraw, which excluded the text label. I've adjusted the `check_changed_queue` function in `code/clocked.js` to request a full redraw for these updates, ensuring the text value is always kept in sync with the actual parameter value.