### PR TITLE
add drag and drop block insertion

### DIFF
--- a/code/blockmanager.js
+++ b/code/blockmanager.js
@@ -522,7 +522,8 @@ var usermouse = {
 		dragging : {
 			connections : [],
 			voices : []
-		}
+		},
+		target_wire_for_insertion: -1
 	}
 }
 

--- a/code/blocks_and_connections.js
+++ b/code/blocks_and_connections.js
@@ -3468,7 +3468,6 @@ function insert_block_in_connection(newblockname,newblock){
 	new_connection.clear();
 	//click_clear(0,0);
 	//outlet(8,"bang");
-	set_display_mode("blocks");
 	var usz=undo_stack.getsize("history")|0;
 	undo_stack.append("history",'{}');
 	undo_stack.setparse("history["+usz+"]", '{ "connections" : { } }');


### PR DESCRIPTION
can now drag a block over an existing cable while holding cmd/ctrl + shift to insert it directly into connection path

- added a `manual_wire_hit_detection` function to solve the issue where the physics picker can't detect wires underneath the block being dragged
- targeted wire "bulges" to provide visual feedback
- refactored the mouse release logic in `omouse` to handle the new insertion action while ensuring the block's final position is always respected