### PR TITLE
fix #874 - muting hw outs

### DIFF
--- a/code/blocks_and_connections.js
+++ b/code/blocks_and_connections.js
@@ -1735,7 +1735,7 @@ function make_connection(cno,existing){
 		max_poly = blocktypes.get(f_name+"::max_polyphony");
 		varr = blocktypes.get(f_name+"::connections::out::hardware_channels");
 		//post("\navailable hw voice out channels:", varr, "max poly", max_poly, "f_voice_list",f_voice_list);
-		hw_mute = blocks.get("blocks["+f_block+"]::mute");
+		hw_mute |= blocks.get("blocks["+f_block+"]::mute");
 		if(!Array.isArray(varr)) varr = [varr];
 		if(max_poly>1){
 			if(f_voice_list == "all"){
@@ -1813,6 +1813,7 @@ function make_connection(cno,existing){
 	}else if(t_type == "hardware"){ // work out which polyvoices/matrix slots correspond
 		max_poly = blocktypes.get(blocks.get("blocks["+t_block+"]::name")+"::max_polyphony");
 		varr = blocktypes.get(blocks.get("blocks["+t_block+"]::name")+"::connections::in::hardware_channels");
+		hw_mute |= blocks.get("blocks["+t_block+"]::mute");
 		if(!Array.isArray(varr)) varr = [varr];
 		if(max_poly>1){
 			if(t_voice_list == "all"){

--- a/code/mouse_helpers.js
+++ b/code/mouse_helpers.js
@@ -2800,6 +2800,7 @@ function mute_particular_block(block,av){ // i=block, av=value, av=-1 means togg
 		}
 	}else if(type == "hardware"){
 		//actually needs to mute or unmute the audio/midi connections for hw blocks
+		// first the signal from the hardware to benny
 		for(var t=0;t<connections.getsize("connections");t++){
 			if(connections.contains("connections["+t+"]::from") && (connections.get("connections["+t+"]::from::number") == block)){
 				// then mute it or unmute it (if the connection itself is not muted)
@@ -2808,6 +2809,19 @@ function mute_particular_block(block,av){ // i=block, av=value, av=-1 means togg
 				}
 			}
 		}
+		// and if the block doesn't have hw->benny, mute the signals the other way
+		if(!blocktypes.contains(blocks.get("blocks["+block+"]::name")+"::connections::out::hardware")){
+			// post("\nthis block is just an output, right?");
+			for(var t=0;t<connections.getsize("connections");t++){
+				if(connections.contains("connections["+t+"]::to") && (connections.get("connections["+t+"]::to::number") == block)){
+					// then mute it or unmute it (if the connection itself is not muted)
+					if((connections.get("connections["+t+"]::conversion::mute")==0) && (connections.get("connections["+t+"]::to::input::type") == "hardware")){
+						make_connection(t,1);
+					}
+				}
+			}
+		}
+
 		//and also if the block has a generic midi handler (or whatever) loaded in a note slot, send that a mute message
 		list = voicemap.get(block);
 		if(list === null){


### PR DESCRIPTION
a few people have been confused by the inability to mute hw outputs. this fixes that but doesn't change any other hw muting behaviour - the change only applies to hw blocks that only take a signal from benny out to the world, and have no returns. eg out 1+2 but not filters etc, ext inputs, etc they already muted fine and nothing extra happens to them now.